### PR TITLE
Feature: Adding OBS transitions

### DIFF
--- a/src/main/kotlin/GUI.kt
+++ b/src/main/kotlin/GUI.kt
@@ -31,6 +31,12 @@ object GUI {
         }
     }
 
+    fun refreshTransitions() {
+        for (component in components.toTypedArray()) {
+            component.refreshTransitions()
+        }
+    }
+
     fun refreshQueItems() {
         val componentsCopy = components.toTypedArray()
         for (component in componentsCopy) {

--- a/src/main/kotlin/gui/Refreshable.kt
+++ b/src/main/kotlin/gui/Refreshable.kt
@@ -6,6 +6,7 @@ interface Refreshable {
     fun refreshTimer() {}
     fun switchedScenes() {}
     fun refreshScenes() {}
+    fun refreshTransitions() {}
     fun refreshQueItems() {}
     fun refreshQueueName() {}
 

--- a/src/main/kotlin/objects/OBSClientStatus.kt
+++ b/src/main/kotlin/objects/OBSClientStatus.kt
@@ -5,6 +5,7 @@ enum class OBSClientStatus(val status: String) {
     CONNECTED("Connected"),
     DISCONNECTED("Disconnected"),
     LOADING_SCENE_SOURCES("Loading scene sources..."),
+    LOADING_TRANSITIONS("Loading transitions..."),
     CONNECTING("Connecting..."),
     RECONNECTING("Reconnecting..."),
     CONNECTION_FAILED("Connection failed!"),

--- a/src/main/kotlin/objects/OBSState.kt
+++ b/src/main/kotlin/objects/OBSState.kt
@@ -3,6 +3,7 @@ package objects
 object OBSState {
     var currentSceneName: String? = null
     val scenes: ArrayList<TScene> = ArrayList()
+    val transitions: ArrayList<TTransition> = ArrayList()
 
     var clientActivityStatus: OBSClientStatus? = null
     var connectionStatus: OBSClientStatus = OBSClientStatus.UNKNOWN

--- a/src/main/kotlin/objects/TTransition.kt
+++ b/src/main/kotlin/objects/TTransition.kt
@@ -1,0 +1,14 @@
+package objects
+
+import java.util.logging.Logger
+
+class TTransition {
+    private val logger = Logger.getLogger(TTransition::class.java.name)
+    var name = ""
+
+    constructor(name: String?) {
+        this.name = name ?: ""
+    }
+
+    override fun toString(): String = name
+}

--- a/src/test/kotlin/gui/OBSStatusPanelTest.kt
+++ b/src/test/kotlin/gui/OBSStatusPanelTest.kt
@@ -70,6 +70,16 @@ class OBSStatusPanelTest {
     }
 
     @Test
+    fun testGetOBSStatusRepresentationWithLoadingTransitionsStatus() {
+        val panel = OBSStatusPanel()
+
+        OBSState.clientActivityStatus = OBSClientStatus.LOADING_TRANSITIONS
+        OBSState.connectionStatus = OBSClientStatus.CONNECTED
+
+        assertEquals("Loading transitions...", panel.getOBSStatusRepresentation())
+    }
+
+    @Test
     fun testMessageLabelWithRefreshingOBSStatus() {
         OBSState.connectionStatus = OBSClientStatus.UNKNOWN
         val panel = OBSStatusPanel()

--- a/src/test/kotlin/main/GUITest.kt
+++ b/src/test/kotlin/main/GUITest.kt
@@ -47,6 +47,16 @@ class GUITest {
     }
 
     @Test
+    fun testRefreshTransitions() {
+        val guiComponentMock = GuiComponentMock()
+        GUI.register(guiComponentMock)
+
+        GUI.refreshTransitions()
+
+        assertTrue(guiComponentMock.refreshTransitionsCalled)
+    }
+
+    @Test
     fun testRefreshOBSStatus() {
         val guiComponentMock = GuiComponentMock()
         GUI.register(guiComponentMock)

--- a/src/test/kotlin/mocks/GuiComponentMock.kt
+++ b/src/test/kotlin/mocks/GuiComponentMock.kt
@@ -5,6 +5,7 @@ import gui.Refreshable
 class GuiComponentMock : Refreshable {
     var switchedScenesCalled: Boolean = false
     var refreshScenesCalled: Boolean = false
+    var refreshTransitionsCalled: Boolean = false
     var refreshOBSStatusCalled: Boolean = false
     var refreshNotificationsCalled: Boolean = false
 
@@ -14,6 +15,10 @@ class GuiComponentMock : Refreshable {
 
     override fun refreshScenes() {
         refreshScenesCalled = true
+    }
+
+    override fun refreshTransitions() {
+        refreshTransitionsCalled = true
     }
 
     override fun refreshOBSStatus() {
@@ -27,6 +32,7 @@ class GuiComponentMock : Refreshable {
     fun resetCalleds() {
         switchedScenesCalled = false
         refreshScenesCalled = false
+        refreshTransitionsCalled = false
         refreshOBSStatusCalled = false
         refreshNotificationsCalled = false
     }

--- a/src/test/kotlin/objects/OBSClientTest.kt
+++ b/src/test/kotlin/objects/OBSClientTest.kt
@@ -4,6 +4,7 @@ import GUI
 import config.Config
 import mocks.GuiComponentMock
 import net.twasi.obsremotejava.objects.Scene
+import net.twasi.obsremotejava.objects.Transition
 import objects.notifications.Notifications
 import kotlin.test.*
 
@@ -21,6 +22,7 @@ class OBSClientTest {
         GUI.register(panelMock)
 
         assertFalse(panelMock.refreshScenesCalled)
+        assertFalse(panelMock.refreshTransitionsCalled)
         assertFalse(panelMock.switchedScenesCalled)
 
         // When
@@ -30,6 +32,7 @@ class OBSClientTest {
         }
 
         assertFalse(panelMock.refreshScenesCalled)
+        assertFalse(panelMock.refreshTransitionsCalled)
         assertTrue(panelMock.switchedScenesCalled)
     }
 
@@ -42,6 +45,7 @@ class OBSClientTest {
         Config.obsAddress = "ws://somewhereNotLocalhost"
 
         assertFalse(panelMock.refreshScenesCalled)
+        assertFalse(panelMock.refreshTransitionsCalled)
         assertFalse(panelMock.switchedScenesCalled)
         assertFalse(panelMock.refreshOBSStatusCalled)
 
@@ -54,9 +58,38 @@ class OBSClientTest {
         OBSClient.processOBSScenesToOBSStateScenes(scenes)
 
         assertTrue(panelMock.refreshScenesCalled)
+        assertFalse(panelMock.refreshTransitionsCalled)
         assertFalse(panelMock.switchedScenesCalled)
         assertTrue(panelMock.refreshOBSStatusCalled)
         assertEquals(3, OBSState.scenes.size)
+        assertNull(OBSState.clientActivityStatus)
+    }
+
+    @Test
+    fun testSetOBSTransitions() {
+        OBSState.clientActivityStatus = OBSClientStatus.LOADING_TRANSITIONS
+        val panelMock = GuiComponentMock()
+        GUI.register(panelMock)
+
+        Config.obsAddress = "ws://somewhereNotLocalhost"
+
+        assertFalse(panelMock.refreshScenesCalled)
+        assertFalse(panelMock.refreshTransitionsCalled)
+        assertFalse(panelMock.switchedScenesCalled)
+        assertFalse(panelMock.refreshOBSStatusCalled)
+
+        val transitions = ArrayList<Transition>()
+        transitions.add(Transition())
+        transitions.add(Transition())
+
+        // When
+        OBSClient.processOBSTransitionsToOBSStateTransitions(transitions)
+
+        assertFalse(panelMock.refreshScenesCalled)
+        assertTrue(panelMock.refreshTransitionsCalled)
+        assertFalse(panelMock.switchedScenesCalled)
+        assertTrue(panelMock.refreshOBSStatusCalled)
+        assertEquals(2, OBSState.transitions.size)
         assertNull(OBSState.clientActivityStatus)
     }
 

--- a/src/test/kotlin/objects/TTransitionTest.kt
+++ b/src/test/kotlin/objects/TTransitionTest.kt
@@ -1,0 +1,25 @@
+package objects
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TTransitionTest {
+
+    @Test
+    fun testTransitionNameGivesName() {
+        val transition = TTransition("transition")
+        assertEquals("transition", transition.name)
+    }
+
+    @Test
+    fun testTransitionToStringGivesName() {
+        val transition = TTransition("transition")
+        assertEquals("transition", transition.toString())
+    }
+
+    @Test
+    fun testEmptyTransitionGivesEmptyString() {
+        val transition = TTransition(null)
+        assertEquals("", transition.toString())
+    }
+}


### PR DESCRIPTION
This PR adds the ability for Transitions to be pulled into OBS via websockets in order to allow for a user to view and specify transitions.

# Overview

This allows plugins to view any "created" transitions in the OBS workspace.  In case it's not obvious (it wasn't to me when I started working on this), what exactly IS an "created" transition?  If you go into your OBS UI, you can see the Scene Transitions section, it looks like this:

![Screen Shot 2020-12-31 at 1 05 14 PM](https://user-images.githubusercontent.com/750307/103421166-f9872e00-4b68-11eb-9c75-ccdd8fb75785.png)

Any "created" transitions are those available in this list:

![Screen Shot 2020-12-31 at 1 05 19 PM](https://user-images.githubusercontent.com/750307/103421177-ff7d0f00-4b68-11eb-9e16-735360049ad4.png)

Note that transitions do NOT include duration (this is handled separately in OBS), it only includes the created transitions by the user, including any properties, for example:

![Screen Shot 2020-12-31 at 1 07 12 PM](https://user-images.githubusercontent.com/750307/103421205-23405500-4b69-11eb-9554-13d7c405649f.png)

For full transparency, I am using this to enable some work I am doing on a new plugin allowing a user to map scene transitions to scene changes.  WIP Plugin here: https://github.com/cbrews/advanced-scene-plugin

# Technical Approach

Here's the mechanics of how this works:

* OBSClient registers a new listener (see OBSClient::registerCallbacks) on the websocket to listen for a TransitionListChanged event (from OBSRemoteController).
* When it receives this event, it requests the new transition list from the websocket (see OBSClient::loadTransitions)
* It drops the transition list data into a new ArrayListe in OBSState
* The GUI triggers a refreshTransitions event (new) that bubbles the transition change to any listening `Refreshable` GUIs.

# Dependencies

This is dependent on the additions to https://github.com/Twasi/websocket-obs-java/pull/22 and should not be merged until obs-scene-que is dependent on a version of net.twasi.obs-websocket-java that contains this code.